### PR TITLE
Allow ContextValue to be used directly as a path

### DIFF
--- a/pyyaks/__init__.py
+++ b/pyyaks/__init__.py
@@ -9,4 +9,4 @@ def test(*args, **kwargs):
     import testr
     return testr.test(*args, **kwargs)
 
-__version__ = '3.3.5'
+__version__ = '4.4'

--- a/pyyaks/context.py
+++ b/pyyaks/context.py
@@ -40,10 +40,10 @@ def render_args(*argids):
     """
     Decorate a function so that the specified arguments are rendered via
     context.render() before being passed to function.  Keyword arguments are
-    unaffected.  
+    unaffected.
 
     Examples::
-    
+
       # Apply render() to all 3 args
       @context.render_args()
       def func(arg1, arg2, arg3):
@@ -66,7 +66,7 @@ def render_args(*argids):
             return func(*newargs, **kwargs)
 
         # Make an effort to copy func_name and func_doc.  Built-ins don't have these.
-        try:   
+        try:
             newfunc.__name__ = func.__name__
             newfunc.__doc__ = func.__doc__
         except AttributeError:
@@ -92,7 +92,7 @@ def update_context(filename, keys=None):
             raise KeyError('ContextDict %s found in %s but not in existing CONTEXT' %
                            (name, filename))
         CONTEXT[name].update(context[name])
-        
+
 def store_context(filename, keys=None):
     """Store the current context to ``filename``.
 
@@ -109,7 +109,7 @@ def store_context(filename, keys=None):
         pickle.dump(dump_context, open(filename, 'wb'))
 
 class ContextValue(object):
-    """Value with context that has a name and modification time. 
+    """Value with context that has a name and modification time.
 
     :param val: initial value (optional)
     :param name: context value name
@@ -172,13 +172,13 @@ class ContextValue(object):
 
     def __unicode__(self):
         return str(self)
-    
+
     def __str__(self):
         strval = val = self._val
         if val is None:
             raise ValueError("Context value '%s' is undefined" % self.fullname)
         template_tag = re.compile(r'{[%{]')
-        try:                            
+        try:
             # Following line will give TypeError unless val is string-like
             while (template_tag.search(val)):
                 template = jinja2.Template(val)
@@ -404,10 +404,9 @@ class _ContextDictAccessor(object):
 
     def __setattr__(self, name, value):
         setattr(self._contextdict[name], self._attr, value)
-        
+
     def __getitem__(self, name):
         return self.__getattr__(name)
-    
+
     def __setitem__(self, name, value):
         self.__setattr__(name, value)
-

--- a/pyyaks/context.py
+++ b/pyyaks/context.py
@@ -201,6 +201,14 @@ class ContextValue(object):
 
         return strval
 
+    def __fspath__(self):
+        """ABC os.PathLike interface ContextValue is directly useable in Path or
+        os.path or open, etc.
+
+        https://docs.python.org/3/library/os.html#os.PathLike
+        """
+        return str(self)
+
     @property
     def type(self):
         return 'value' if (self.basedir is None) else 'file'

--- a/pyyaks/tests/test_context.py
+++ b/pyyaks/tests/test_context.py
@@ -19,7 +19,6 @@ files = context.ContextDict('files', basedir='pyyaks:data')
 def test_fspath(tmpdir):
     """Test ContextValue.__fspath__() for PathLike ABC"""
 
-    # tmpdir = str(tmpdir)
     filename = 'junk'
     src['junk'] = filename
     fs = context.ContextDict('test_fspath', basedir=str(tmpdir))


### PR DESCRIPTION
With this update, context values can be used directly in any method that takes a os.PathLike object, e.g. `Path` or `os.path` methods.  In this way it is not required to use the `.abs` or `.rel` properties everywhere.

This only works with Python 3.6+, so updating the version to be 4.x.