### PR TITLE
Fix tests to pass on Windows

### DIFF
--- a/pyyaks/tests/test_context.py
+++ b/pyyaks/tests/test_context.py
@@ -67,10 +67,10 @@ def test_nested():
     assert str(src['srcdir']) == 'obs123/nested2'
 
 def test_get_accessor():
-    assert files.rel['srcdir'] == 'data/obs123/nested2'
+    assert files.rel['srcdir'] == str(Path('data/obs123/nested2'))
 
 def test_get_attr():
-    assert files.rel.srcdir == 'data/obs123/nested2'
+    assert files.rel.srcdir == str(Path('data/obs123/nested2'))
 
 def test_auto_create():
     src['ra'].format = '%.2f'
@@ -85,17 +85,17 @@ def test_format():
 
 def test_file_rel():
     assert str(files['evt2']) == files['evt2'].rel
-    assert str(files['evt2.fits']) == 'data/obs123/nested2/acis_evt2.fits'
-    assert context.render('{{files.evt2.fits}}') == 'data/obs123/nested2/acis_evt2.fits'
+    assert str(files['evt2.fits']) == str(Path('data/obs123/nested2/acis_evt2.fits'))
+    assert context.render('{{files.evt2.fits}}') == str(Path('data/obs123/nested2/acis_evt2.fits'))
 
 def test_file_abs():
-    assert files['evt2.fits'].abs == os.path.join(os.getcwd(), 'data/obs123/nested2/acis_evt2.fits')
+    assert files['evt2.fits'].abs == os.path.join(os.getcwd(), str(Path('data/obs123/nested2/acis_evt2.fits')))
 
 def test_multiple_basedir_paths():
     files['context'] = 'context'
-    assert files['context.py'].rel == 'pyyaks/context.py'
-    assert files['context.py'].abs == os.path.join(os.getcwd(), 'pyyaks/context.py')
-    assert files['evt2.fits'].rel == 'data/obs123/nested2/acis_evt2.fits'
+    assert files['context.py'].rel == str(Path('pyyaks/context.py'))
+    assert files['context.py'].abs == os.path.join(os.getcwd(), 'pyyaks', 'context.py')
+    assert files['evt2.fits'].rel == str(Path('data/obs123/nested2/acis_evt2.fits'))
 
 def test_dot_in_key():
     with pytest.raises(ValueError):
@@ -103,8 +103,8 @@ def test_dot_in_key():
 
 def test_abs_file1():
     files['abs'] = '/usr/bin/env'
-    assert files['abs'].rel == '/usr/bin/env'
-    assert files['abs'].abs == '/usr/bin/env'
+    assert files['abs'].rel == str(Path('/usr/bin/env').absolute())
+    assert files['abs'].abs == str(Path('/usr/bin/env').absolute())
 
 def test_abs_file2():
     files['abs'] = os.getcwd()
@@ -149,19 +149,19 @@ def test_store_update_context():
 
     assert str(src['ra']) == '1.4343'
     assert str(src['srcdir']) == 'obs123/nested2'
-    assert files['srcdir'].rel == 'data/obs123/nested2'
-    assert files.rel.srcdir == 'data/obs123/nested2'
-    assert str(files['evt2.fits']) == 'data/obs123/nested2/acis_evt2.fits'
+    assert files['srcdir'].rel == str(Path('data/obs123/nested2'))
+    assert files.rel.srcdir == str(Path('data/obs123/nested2'))
+    assert str(files['evt2.fits']) == str(Path('data/obs123/nested2/acis_evt2.fits'))
 
 def test_update_basedir():
     files['tmpfile'] = 'tmpfile'
     a = files['tmpfile']
-    assert files['tmpfile'].rel == 'data/tmpfile'
+    assert files['tmpfile'].rel == str(Path('data/tmpfile'))
     files.basedir = 'newdata'
-    assert files['tmpfile'].rel == 'newdata/tmpfile'
-    assert a.rel == 'newdata/tmpfile'
+    assert files['tmpfile'].rel == str(Path('newdata/tmpfile'))
+    assert a.rel == str(Path('newdata/tmpfile'))
     files.basedir = 'data'
-    assert files['tmpfile'].rel == 'data/tmpfile'
+    assert files['tmpfile'].rel == str(Path('data/tmpfile'))
 
 
 def test_context_cache():

--- a/pyyaks/tests/test_logger.py
+++ b/pyyaks/tests/test_logger.py
@@ -2,6 +2,7 @@
 from __future__ import print_function, division, absolute_import
 
 import tempfile
+import os
 from .. import logger as pyyaks_logger
 import six
 
@@ -35,29 +36,29 @@ def test_stream():
     logger.info('Info')
     logger.warning('Warning')
     assert stdout.getvalue() == "Info\nWarning\n"
-    
-def test_file():
-    tmp = tempfile.NamedTemporaryFile()
-    logger = pyyaks_logger.get_logger(filename=tmp.name, stream=None)
+
+def test_file(tmpdir):
+    tmp = os.path.join(tmpdir, 'tmp.log')
+    logger = pyyaks_logger.get_logger(filename=tmp, stream=None)
     logger.debug('Debug')
     logger.info('Info')
     logger.warning('Warning')
-    assert open(tmp.name).read() == "Info\nWarning\n"
-    
-def test_redefine():
+    assert open(tmp).read() == "Info\nWarning\n"
+
+def test_redefine(tmpdir):
     stdout1 = six.StringIO()
     stdout2 = six.StringIO()
-    tmp1 = tempfile.NamedTemporaryFile()
-    tmp2 = tempfile.NamedTemporaryFile()
-    logger = pyyaks_logger.get_logger(filename=tmp1.name, stream=stdout1, filelevel=pyyaks_logger.WARNING)
+    tmp1 = os.path.join(tmpdir, 'tmp1.log')
+    tmp2 = os.path.join(tmpdir, 'tmp2.log')
+    logger = pyyaks_logger.get_logger(filename=tmp1, stream=stdout1, filelevel=pyyaks_logger.WARNING)
     logger.debug('Debug1')
     logger.info('Info1')
     logger.warning('Warning1')
-    logger = pyyaks_logger.get_logger(filename=tmp2.name, stream=stdout2, level=pyyaks_logger.DEBUG)
+    logger = pyyaks_logger.get_logger(filename=tmp2, stream=stdout2, level=pyyaks_logger.DEBUG)
     logger.debug('Debug2')
     logger.info('Info2')
     logger.warning('Warning2')
-    assert open(tmp1.name).read() == "Warning1\n"
+    assert open(tmp1).read() == "Warning1\n"
     assert stdout1.getvalue() == "Info1\nWarning1\n"
-    assert open(tmp2.name).read() == "Debug2\nInfo2\nWarning2\n"
+    assert open(tmp2).read() == "Debug2\nInfo2\nWarning2\n"
     assert stdout2.getvalue() == "Debug2\nInfo2\nWarning2\n"


### PR DESCRIPTION
## Description

Mostly related to forward slash vs. back slash in the string representation of path names.  Also, windows does not allow opening a file which already has an open filehandle.

## Testing

- [x] Passes unit tests on MacOS, Windows
